### PR TITLE
Adding support for setting custom region

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ aws-signing-proxy is a proxy service, written in go, for automatically signing r
 ```
 export AWS_ACCESS_KEY_ID=<xxx>
 export AWS_SECRET_ACCESS_KEY=<xxx>
+export AWS_REGION=<xxx>
 ./aws-signing-proxy -target https://search-my-cluster.us-west-2.es.amazonaws.com
 ```
 


### PR DESCRIPTION
I've added support for a new commandline flag: `-region`.

When `-region` isn't set, it will default to `$AWS_REGION`, or `us-west-2` as before.

Signed-off-by: Dave Henderson dhenderson@gmail.com
