### PR TITLE
Added support to read target for env (AWS_ES_TARGET)

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 )
 
-var targetFlag = flag.String("target", "", "target url to proxy to")
+var targetFlag = flag.String("target", os.Getenv("AWS_ES_TARGET"), "target url to proxy to")
 var portFlag = flag.Int("port", 8080, "listening port for proxy")
 var regionFlag = flag.String("region", os.Getenv("AWS_REGION"), "AWS region for credentials")
 


### PR DESCRIPTION
Added support to read the target from environment variable `AWS_ES_TARGET` useful when using aws-signing-proxy on docker images that read all settings from environment.

The change seems simple and harmless and for me is very useful :)

(PD: thanks for the tool)
