### PR TITLE
make service-name configurable to be able to use e.g. s3 also

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 )
 
+var serviceName = flag.String("service-name", os.Getenv("AWS_SERVICE_NAME"), "service-name to use")
 var targetFlag = flag.String("target", os.Getenv("AWS_ES_TARGET"), "target url to proxy to")
 var portFlag = flag.Int("port", 8080, "listening port for proxy")
 var regionFlag = flag.String("region", os.Getenv("AWS_REGION"), "AWS region for credentials")
@@ -42,8 +43,12 @@ func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region str
 		// sign the request
 		config := aws.NewConfig().WithCredentials(creds).WithRegion(region)
 
+		if serviceName == nil {
+			*serviceName = "es"
+		}
+
 		clientInfo := metadata.ClientInfo{
-			ServiceName: "es",
+			ServiceName: *serviceName,
 		}
 
 		operation := &request.Operation{


### PR DESCRIPTION
Hey!
I just saw your proxy and was wondering if it can also be used to access non-public AWS-S3 content.
Turns out it can. Only the hard-coded serviceName needs to be changed.

This PR make the serviceName configurable over die CLI.

Let me know what you think.

Regards,

Kai