### PR TITLE
Pass Escaped path to AWS operation

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func NewSigningProxy(target *url.URL, creds *credentials.Credentials, region str
 		operation := &request.Operation{
 			Name:       "",
 			HTTPMethod: req.Method,
-			HTTPPath:   req.URL.Path,
+			HTTPPath:   req.URL.EscapedPath(),
 		}
 
 		handlers := request.Handlers{}


### PR DESCRIPTION
The AWS SDK will error out if it cannot parse the HTTPPath of the operation while signing.

This means that if you have an index in ES that has a name that contains a potential URL escape the signing proxy will error out with invalid URL escape "%xx"

In the example below I have an index that was erronously created with a name that includes the token `%{t`. When that URL is parsed the parser breaks trying to interpret that sequence as a URL escape. 
```
2019/02/22 14:31:58 error signing: InvalidEndpointURL: invalid endpoint uri
caused by: parse /_cluster/state/metadata/%{team}.an-index-2020.01: invalid URL escape "%{t"
```

This sequence should be escaped before being passed along resulting in safe url shown below:
```
/_cluster/state/metadata/%25%7Bteam%7D.an-index-2020.01
```

This change uses [req.Path.EscapedPath()](https://golang.org/pkg/net/url/#URL.EscapedPath) to grab this safe path and passes it along to the AWS SDK for signing.