### PR TITLE
log failure to start service (e.g., port already in use)

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,5 +188,5 @@ func main() {
 	proxy := NewSigningProxy(targetURL, creds, region, appC)
 	listenString := fmt.Sprintf(":%v", *portFlag)
 	fmt.Printf("Listening on %v\n", listenString)
-	http.ListenAndServe(listenString, proxy)
+	log.Fatal(http.ListenAndServe(listenString, proxy))
 }


### PR DESCRIPTION
Previously, failure to bind would result in a silent failure after the "Listening on <port>" message. This change wraps the call to `ListenAndServe` to report any failure.

```bash
# ./aws-signing-proxy -target https://my-endpoint.amazonaws.com -port 9999 &
[3] 26203
Listening on :9999

# ./aws-signing-proxy -target https://my-endpoint.amazonaws.com -port 9999
Listening on :9999
2019/04/19 11:51:43 listen tcp :9999: bind: address already in use
```
